### PR TITLE
add tests to cover all annotations

### DIFF
--- a/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean.java
+++ b/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean.java
@@ -1,12 +1,14 @@
 package org.jboss.ejb3.extapi.testcompilation;
 
+import java.util.concurrent.TimeUnit;
+
 import org.jboss.ejb3.annotation.DeliveryActive;
+import org.jboss.ejb3.annotation.DeliveryGroup;
+import org.jboss.ejb3.annotation.DeliveryGroups;
 import org.jboss.ejb3.annotation.ResourceAdapter;
 import org.jboss.ejb3.annotation.RunAsPrincipal;
 import org.jboss.ejb3.annotation.SecurityDomain;
 import org.jboss.ejb3.annotation.TransactionTimeout;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * A Test Object for compilation only to ensure that the 
@@ -24,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 @SecurityDomain(value="securityDomain",unauthenticatedPrincipal="unAuthPrincipal")
 @TransactionTimeout(value = 0, unit = TimeUnit.MINUTES)
 @DeliveryActive(false)
+@DeliveryGroups({@DeliveryGroup("group1"), @DeliveryGroup("group2")})
 public class TestCompilationBean
 {
 }

--- a/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean2.java
+++ b/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean2.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb3.extapi.testcompilation;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.ejb3.annotation.Cache;
+import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.ejb3.annotation.ClusteredSingleton;
+import org.jboss.ejb3.annotation.DeliveryGroup;
+import org.jboss.ejb3.annotation.Pool;
+import org.jboss.ejb3.annotation.TransactionTimeout;
+
+@Clustered
+@ClusteredSingleton
+@Cache("cache1")
+@Pool("pool1")
+@DeliveryGroup("group1")
+@DeliveryGroup("group2")
+public class TestCompilationBean2 {
+    @TransactionTimeout(value = 1, unit = TimeUnit.HOURS)
+    public void method1() {
+    }
+}


### PR DESCRIPTION
Add a new test class that uses the following annotations that have not been covered by existing tests:
* @Clustered
* @ClusteredSingleton
* @Cache("cache1")
* @Pool("pool1")
* @DeliveryGroup("group1")

This PR also covers the repeatable annotation `@DeliveryGroup`, so that both `@DeliveryGroups` and repeating `@DeliveryGroup` are tested.

In addition to the existing use of type-level `@TransactionTimeout`, this annotation is now also tested at method-level in `TestCompilationBean2`.